### PR TITLE
Preserve context when using `co.wrap()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * toString reference.
  */
@@ -97,9 +96,10 @@ function co(fn, done, ctx) {
 exports.wrap = function(fn, ctx){
   return function(){
     var args = [].slice.call(arguments);
+    ctx = ctx || this;
     return function(done){
       args.push(done);
-      fn.apply(ctx || this, args);
+      fn.apply(ctx, args);
     }
   }
 };


### PR DESCRIPTION
When wrapping prototype/instance methods, you don't have the context available to pass to `co.wrap()`. This commit defaults the context to the caller of the method being wrapped, instead of the thunk returned.
