### PR TITLE
make the `isGenerator()` function more generic

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ function isPromise(obj) {
 }
 
 /**
- * Check if `fn` is a generator.
+ * Check if `obj` is a generator.
  *
  * @param {Mixed} obj
  * @return {Boolean}
@@ -197,7 +197,7 @@ function isGenerator(obj) {
 }
 
 /**
- * Check if `fn` is a generator function.
+ * Check if `obj` is a generator function.
  *
  * @param {Mixed} obj
  * @return {Boolean}


### PR DESCRIPTION
For some background, see this Twitter conversation:
https://twitter.com/TooTallNate/status/397185683162288128

tl;dr this works with both regenerator as well as native V8 generators,
and it is probably faster in general, so hey why not. Yay JS………
