### PR TITLE
add generators and delegated generators benchmarks

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -8,7 +8,7 @@ function fun(done) {
 }
 
 function *gen() {
-  
+
 }
 
 function getPromise(val, err) {
@@ -19,8 +19,8 @@ function getPromise(val, err) {
 }
 
 suite('co()', function(){
-  set('mintime', 1000)
-  
+  set('mintime', process.env.MINTIME | 0 || 1)
+
   bench('promises', function(done){
     co(function *(){
       yield getPromise(1);
@@ -40,6 +40,22 @@ suite('co()', function(){
   bench('thunk join', function(done){
     co(function *(){
       yield [fun, fun, fun];
+    })(done);
+  })
+
+  bench('generators', function(done){
+    co(function *(){
+      yield gen();
+      yield gen();
+      yield gen();
+    })(done);
+  })
+
+  bench('generators delegated', function(done){
+    co(function *(){
+      yield* gen();
+      yield* gen();
+      yield* gen();
     })(done);
   })
 


### PR DESCRIPTION
just found out there's `yield* generator` which is supposed to be faster - and it is! so i added a benchmark:

![screen shot 2013-11-09 at 2 26 03 pm](https://f.cloud.github.com/assets/643505/1507577/1c49fdc6-498e-11e3-88b6-01228a2ada9e.png)

now the problem is that if i set the `mintime` too high, i'll get the following error:

![screen shot 2013-11-09 at 2 28 10 pm](https://f.cloud.github.com/assets/643505/1507578/3ae989e0-498e-11e3-8f2c-1500327e7475.png)

thus, i just made it an environmental variable and set it to `1` millisecond by default. i'm not sure why that happens.
