### PR TITLE
fix "Generator is already running" errors when no callback provided

### DIFF
--- a/test/generator-functions.js
+++ b/test/generator-functions.js
@@ -29,20 +29,5 @@ describe('co(fn)', function(){
         res.should.eql(['yay', 'yay', 'yay']);
       })(done);
     })
-
-    it('should pass arguments into generator', function(done) {
-      co(function *(a, b) {
-        assert('yay' == a);
-        assert('wahoo' == b);
-      })('yay', 'wahoo', done);
-    });
-
-    it('should pass arguments into generator with yields', function(done) {
-      co(function *(a, b) {
-        assert('yay' == a);
-        yield work
-        assert('wahoo' == b);
-      })('yay', 'wahoo', done);
-    });
   })
 })

--- a/test/receiver.js
+++ b/test/receiver.js
@@ -44,19 +44,6 @@ describe('co.call(receiver)', function(){
     })(done);
   })
 
-  it('should pass args', function(done){
-    function foo(done) {
-      assert(this == ctx);
-      done();
-    }
-
-    co.call(ctx, function *(a){
-      assert('yay' == a);
-      assert(ctx == this);
-      yield foo;
-    })('yay', done);
-  })
-
   it('should set join delegate generator receiver', function(done){
     function *baz() {
       assert(ctx == this);


### PR DESCRIPTION
this is https://github.com/visionmedia/co/pull/50, but specifically when no callback is provided. adapted your diff and only the relevant test cases are included.

note: this removes arguments support because it becomes too complicated to check if the last argument was a callback. i'm going to do a PR for https://github.com/visionmedia/co/pull/50#issuecomment-28863545 anyways.
