### PR TITLE
make context and arguments be passed through thunk

### DIFF
--- a/test/receiver.js
+++ b/test/receiver.js
@@ -9,11 +9,11 @@ var ctx = {
   foo: 'bar'
 };
 
-describe('co.call(receiver)', function(){
+describe('co(receiver).call(ctx)', function(){
   it('should set immediate gen receiver', function(done){
-    co.call(ctx, function *(){
+    co(function *(){
       assert(ctx == this);
-    })(done);
+    }).call(ctx, done);
   })
 
   it('should set delegate generator receiver', function(done){
@@ -26,10 +26,10 @@ describe('co.call(receiver)', function(){
       yield bar;
     }
 
-    co.call(ctx, function *(){
+    co(function *(){
       assert(ctx == this);
       yield foo;
-    })(done);
+    }).call(ctx, done);
   })
 
   it('should set function receiver', function(done){
@@ -38,10 +38,10 @@ describe('co.call(receiver)', function(){
       done();
     }
 
-    co.call(ctx, function *(){
+    co(function *(){
       assert(ctx == this);
       yield foo;
-    })(done);
+    }).call(ctx, done);
   })
 
   it('should set join delegate generator receiver', function(done){
@@ -57,10 +57,10 @@ describe('co.call(receiver)', function(){
       assert(ctx == this);
     }
 
-    co.call(ctx, function *(){
+    co(function *(){
       assert(ctx == this);
       yield [foo, bar, baz];
-    })(done);
+    }).call(ctx, done);
   })
 
   it('should set join function receiver', function(done){
@@ -79,9 +79,39 @@ describe('co.call(receiver)', function(){
       done();
     }
 
-    co.call(ctx, function *(){
+    co(function *(){
       assert(ctx == this);
       yield [foo, bar, baz];
-    })(done);
+    }).call(ctx, done);
+  })
+})
+
+describe('co(receiver)(args...)', function(){
+  it('should pass arguments to the receiver', function(done){
+    co(function *(a, b, c){
+      assert(a == 1);
+      assert(b == 2);
+      assert(c == 3);
+    })(1, 2, 3, done);
+  })
+
+  it('should not pass the callback to the receiver', function(done){
+    co(function *(a, b, c){
+      assert(arguments.length == 3);
+    })(1, 2, 3, done);
+  })
+
+  it('should work when less arguments are passed than expected', function(done){
+    co(function *(a, b, c){
+      assert(a == 1);
+      assert(arguments.length == 1);
+    })(1, done);
+  })
+
+  it('should work without a callback', function(){
+    co(function *(a, b, c){
+      assert(a == 1);
+      assert(arguments.length == 1);
+    })(1);
   })
 })

--- a/test/thunks.js
+++ b/test/thunks.js
@@ -12,13 +12,6 @@ function get(val, err, error) {
 }
 
 describe('co(fn)', function(){
-  it('should have the same receiver', function(done){
-    var foo = { thread: co };
-    foo.thread(function *(){
-      this.should.equal(foo);
-    })(done);
-  })
-
   describe('with no yields', function(){
     it('should work', function(done){
       co(function *(){


### PR DESCRIPTION
this is kind of an opinionated PR and it would break compatibility (though we already broke it by removing arguments). instead of doing `co.call(this, gen)(args..., done)`, we now "compose" a generator function into a regular asynchronous function. the signature would now be `co(gen).call(this, args..., done)`. so:

``` js
co(function *(a, b, c) {

})
```

returns:

``` js
function (a, b, c, done) {

}
```

i always thought it was weird how you call `this` and the arguments in different parts. 

now, co returns a reusable function. now users don't have to `require('co')` just to consume it.  it would also make koa's callback simpler:

``` js
app.callback = function(){
  var mw = [respond].concat(this.middleware);
  var run = co(compose(mw));
  var self = this;

  return function(req, res, next){
    var ctx = self.createContext(req, res);
    run.call(ctx, next || ctx.onerror);
  }
};
```
