### PR TITLE
Fix typo in History.md

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,10 +2,6 @@
 ==================
 
  * fixed: callback passed as an argument to generators
-
-3.0.0 / 2013-12-19
-==================
-
  * change: `co(function *(){})` now returns a reusable thunk
  * change: `this` must now be passed through the returned thunk, ex. `co(function *(){}).call(this)`
  * fix "generator already finished" errors


### PR DESCRIPTION
'3.0.0 / 2013-12-19' is shown twice.

---
- Before:
  ![2013-12-26 23 39 41](https://f.cloud.github.com/assets/290782/1810902/af4cf1ba-6e3b-11e3-8843-c369cf27e34d.png)
- After:
  ![2013-12-26 23 40 16](https://f.cloud.github.com/assets/290782/1810903/b2f2db4a-6e3b-11e3-82f0-c54e606dc87a.png)
