### PR TITLE
bug: nil argument in first position replaced with error fn

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ function co(fn) {
     // with a generator, so optimize for
     // this case
     var gen = fn;
-    done = done || error;
 
     if (isGenFun) {
       // we only need to parse the arguments
@@ -50,6 +49,8 @@ function co(fn) {
       else done = error;
 
       gen = fn.apply(this, args);
+    } else {
+      done = done || error;
     }
 
     next();

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -6,4 +6,10 @@ describe('co()(args...)', function(){
   it('should not pass the thunk as an arguments', co(function *(){
     assert.equal(arguments.length, 0);
   }))
+
+  it('should not pass error for nil first argument', function(done){
+    co(function *(i){
+      assert.equal(i, 0);
+    })(0, done);
+  });
 })


### PR DESCRIPTION
If invoking with nil argument (`0`, `null`, `false`) as first argument to generator function it would be replaced with the `error` function.

``` js
co(function*(bln) {
  bln.should.be.a('boolean'); // => fails (equals [Function: error])
})(false, done);
```
