### PR TITLE
Example of binding function as thunk.

### DIFF
--- a/examples/bind.js
+++ b/examples/bind.js
@@ -1,0 +1,11 @@
+var co = require('..'),
+	fs = require('fs');
+
+co(function *() {
+	var directories = yield fs.readdir.bind(fs, './../');
+
+	directories.forEach(function(directory) {
+		console.log(directory);
+	});
+  
+})();


### PR DESCRIPTION
Instead of always 'thunkifying' an object, how about using the native bind function? This PR request just adds the following to the `examples`. Maybe it may come in handy as another method of creating thunks without the extra dependency.

``` js
var co = require('..'),
    fs = require('fs');

co(function *() {
    var directories = yield fs.readdir.bind(fs, './../');

    directories.forEach(function(directory) {
        console.log(directory);
    });

})();
```
