### PR TITLE
expose toThunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ var slice = Array.prototype.slice;
 module.exports = co;
 
 /**
+ * Expose `toThunk`
+ */
+
+co.toThunk = toThunk;
+
+/**
  * Wrap the given generator `fn` and
  * return a thunk.
  *


### PR DESCRIPTION
`toThunk` is powerful when writing some co libraries. 

in [co-any](https://github.com/dead-horse/co-any). i had to copy these code from `co`

expose it and make everybody can use it.
