### PR TITLE
index: add `setImmediate()` fallback to `process.nextTick`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ var toString = Object.prototype.toString;
 var slice = Array.prototype.slice;
 
 /**
+ * setImmediate() with fallback to process.nextTick() for node v0.8.x.
+ */
+
+var setImmediate = global.setImmediate || process.nextTick;
+
+/**
  * Expose `co`.
  */
 


### PR DESCRIPTION
For v0.8 compatibility. Yes, `co` is indeed usable with v0.8
using things like `gnode` and/or `facebook/regenerator` :)
