### PR TITLE
Remove duplicate code in toThunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,9 +127,6 @@ function co(fn) {
  */
 
 function toThunk(obj, ctx) {
-  if (Array.isArray(obj)) {
-    return objectToThunk.call(ctx, obj);
-  }
 
   if (isGeneratorFunction(obj)) {
     return co(obj.call(ctx));


### PR DESCRIPTION
`Array.isArray(obj)` is contained in both first and last `if` statement. I wonder is this for  performance?
