### PR TITLE
Update http example to work immediately

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -224,8 +224,9 @@ co(function *(){
   Or if the generator functions do not require arguments, simply `yield` the function:
 
 ```js
+var co = require('co');
 var thunkify = require('thunkify');
-var request = require('superagent');
+var request = require('request');
 
 var get = thunkify(request.get);
 


### PR DESCRIPTION
Currenty version of superagent passes something truthy to the first argument of the callback so co thinks this is an error.  Doesn't happen with request.
