### PR TITLE
closes #125 better error stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,11 @@ function co(fn) {
       }
 
       // invalid
-      next(new TypeError('You may only yield a function, promise, generator, array, or object, '
-        + 'but the following was passed: "' + String(ret.value) + '"'));
+      err = new TypeError('You may only yield a function, promise, generator, array, or object, '
+        + 'but the following was passed: "' + String(ret.value) + '"')
+
+      gen.throw(err);
+      exit();
     }
   }
 }

--- a/test/thunks.js
+++ b/test/thunks.js
@@ -192,25 +192,17 @@ describe('co(fn)', function(){
 
   describe('when yielding neither a function nor a promise', function(){
     it('should throw', function(done){
-      var errors = [];
+      var error
 
       co(function *(){
         try {
           var a = yield 'something';
         } catch (err) {
-          errors.push(err.message);
+          error = err.message;
         }
 
-        try {
-          var a = yield 'something';
-        } catch (err) {
-          errors.push(err.message);
-        }
-
-        errors.length.should.equal(2);
         var msg = 'yield a function, promise, generator, array, or object';
-        errors[0].should.include(msg);
-        errors[1].should.include(msg);
+        error.should.include(msg);
       })(done);
     })
   })


### PR DESCRIPTION
For some reason wrapping `gen.throw()` in a `try/catch` always ends up being catched.
That's why we can't call next(err).

Personally I think we should drastically change the implementation of this, because the stack trace of any error bubbling up in the _yieldabe_ should point to the yield line with gen.throw.

Also after a `gen.throw()` you can't yield anymore, the generator appears to be **closed**

Some of this behavior is documented here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators
