### PR TITLE
Benchmarks that measure co's performance ONLY (not bluebird, node's, or matcha)

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -46,32 +46,32 @@ function promiseRunner(done) {
 suite('co()', function(){
   set('mintime', process.env.MINTIME | 0 || 2000)
 
-  bench('promises', function(done){
+  bench('promises',
     co(function *(){
       var getPromise = yield promiseRunner;
       yield getPromise(1);
       yield getPromise(2);
       yield getPromise(3);
-    })(done);
-  })
+    })
+  )
 
-  bench('async thunks', function(done){
+  bench('async thunks',
     co(function *(){
       var thunk = yield thunkRunner;
       yield thunk;
       yield thunk;
       yield thunk;
-    })(done);
-  })
+    })
+  )
 
-  bench('arrays', function(done){
+  bench('arrays',
     co(function *(){
       yield setImmediate;
       yield [fun, fun, fun];
-    })(done);
-  })
+    })
+  )
 
-  bench('objects', function(done){
+  bench('objects'
     co(function *(){
       yield setImmediate;
       yield {
@@ -79,19 +79,19 @@ suite('co()', function(){
         b: fun,
         c: fun
       };
-    })(done);
-  })
+    })
+  )
 
-  bench('generators', function(done){
+  bench('generators',
     co(function *(){
       yield setImmediate;
       yield gen();
       yield gen();
       yield gen();
-    })(done);
-  })
+    })
+  )
 
-  bench('generators delegated', function(done){
+  bench('generators delegated',
     co(function *(){
       yield setImmediate;
       yield* gen();
@@ -100,12 +100,12 @@ suite('co()', function(){
     })(done);
   })
 
-  bench('generator functions', function(done){
+  bench('generator functions',
     co(function *(){
       yield setImmediate;
       yield gen;
       yield gen;
       yield gen;
-    })(done);
-  })
+    })
+  )
 })


### PR DESCRIPTION
The thunks measurement was based on synchronous (recursive) callbacks into co, but node I/O callbacks are never invoked until _after_ the API call returns.  This change gives a (somewhat) better idea of actual callback performance.  process.nextTick is used in order to minimize the impact of delaying the callback (so we're not measuring node's I/O loop), and only the thunk benchmark is changed, because including context switching overhead in the other benchmarks would effectively measure it _twice_.

I renamed the benchmark so that it'll be clearer that it's not measuring exactly the same thing any more.
