### PR TITLE
Update to use correct term 'control flow'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
   [![Build Status](https://travis-ci.org/visionmedia/co.svg?branch=master)](https://travis-ci.org/visionmedia/co)
 
-  Generator based flow-control goodness for nodejs and the browser, using
+  Generator based control flow goodness for nodejs and the browser, using
   thunks _or_ promises, letting you write non-blocking code in a nice-ish
   way.
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "co",
   "version": "3.1.0",
-  "description": "generator async flow control goodness",
+  "description": "generator async control flow goodness",
   "keywords": [
     "async",
     "flow",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "co",
   "version": "3.1.0",
-  "description": "generator async flow control goodness",
+  "description": "generator async control flow goodness",
   "keywords": [
     "async",
     "flow",


### PR DESCRIPTION
Just a tiny change set to use the proper terminology. This is a common mixup, but just so happens to be one of my pet peeves.

_For reference:_
- Flow control — controlling rate of transmission
- Control flow — controlling order of execution
