### PR TITLE
add 'engines' property on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "index.js"
   ],
   "license": "MIT",
-  "repository": "tj/co"
+  "repository": "tj/co",
+  "engines": {
+    "node": ">= 0.11.13"
+  }
 }


### PR DESCRIPTION
Let npm show warnning info when user current node version not match:

``` bash
npm WARN engine co@4.0.0: wanted: {"node":">= 0.11.13"} (current: {"node":"0.10.33","npm":"1.4.0"})
```
