### PR TITLE
added test for issue #178

### DIFF
--- a/test/promises.js
+++ b/test/promises.js
@@ -49,4 +49,16 @@ describe('co(* -> yield <promise>', function(){
       });
     })
   })
+
+  describe('when yielding a non-standard promise-like', function() {
+
+    it('should return a real Promise', function() {
+
+        assert(co(function*() {
+          yield {then: function() {}} ;
+        }) instanceof Promise);
+
+    });
+
+  })
 })


### PR DESCRIPTION
The test would fail for 4.0.1 where there's no wrapping `Promise.resolve` and would succeed in 4.0.1.
