### PR TITLE
implement alternate generatorfunction test

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,9 +213,16 @@ function isGenerator(obj) {
  */
 
 function isGeneratorFunction(obj) {
-  var constructor = obj.constructor;
-  return constructor && 'GeneratorFunction' == constructor.name;
+  return obj && obj.constructor == generator.constructor;
 }
+
+/**
+ * Empty generator function for constructor comparison.
+ *
+ * @api private
+ */
+
+function* generator() {}
 
 /**
  * Check for plain object.


### PR DESCRIPTION
co's `isGeneratorFunction` test requires the constructor name to equal `'GeneratorFunction'`, which although conforms to the spec, has caused issues with scripts transpiled to es5 (https://github.com/google/traceur-compiler/issues/616) (https://github.com/facebook/regenerator/issues/48).  

Both traceur and regenerator have fixed this issue by wrapping generators in their runtimes, but if either runtime is minified that  constructor name, `GeneratorFunction`, will be compressed/removed and the test will fail.

Testing against the constructor of a known generator makes the constructor name irrelevant, and the code is just as straight-forward.