### PR TITLE
Add fallback generator function test

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,19 +211,15 @@ function isGenerator(obj) {
  * @return {Boolean}
  * @api private
  */
-
 function isGeneratorFunction(obj) {
-  return obj && obj.constructor == generator.constructor;
+  var constructor = obj.constructor;
+  var proto = constructor.prototype;
+  var name = constructor.displayName || constructor.name;
+  var nameLooksRight = 'GeneratorFunction' == name;
+  var methodsLooksRight = 'function' == typeof proto.next &&
+                          'function' == typeof proto.throw;
+  return nameLooksRight || methodsLooksRight;
 }
-
-/**
- * Empty generator function for constructor comparison.
- * This allows comparisons to work with ES6 transpilers.
- *
- * @api private
- */
-
-function* generator() {}
 
 /**
  * Check for plain object.


### PR DESCRIPTION
Hopefully this fixes #192. If `function*` is not supported, `isGeneratorFunction` falls back to the old testing method. [`regenerator` runtime uses the `displayName`](https://github.com/facebook/regenerator/blob/master/runtime.js#L78) property to avoid problems during minification (because  `GeneratorFunction` is renamed during the process).

Not tested with Traceur...