### PR TITLE
Add co.callback(...)

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,25 @@ co.wrap = function (fn) {
 };
 
 /**
+ * Wrap the given generator `fn` into a
+ * callback. This is useful for middleware.
+ * 
+ *
+ * @param {GeneratorFunction} fn
+ * @return {Function}
+ * @api public
+ */
+co.callback = function (fn) {
+  // The cb argument is included for things
+  // like mocha that check arguments length
+  return function (cb) {
+    var args = slice.call(arguments)
+    cb = args.pop()
+    co(gen.apply(this, args)).then(cb.bind(null, null), cb)
+  }
+}
+
+/**
  * Execute the generator function or a generator
  * and return a promise.
  *


### PR DESCRIPTION
This brings back the old callback-style behaviour, which is handy for middleware.

Before the conversion to promises, you could replace something like:
```
doStuff(function (data, done) {
  fs.readFile(data.file, done)
})
```
with something like:
```
var readFile = thunkify(fs.readFile)
doStuff(co(function* (data) {
  return yield readFile(data.file)
})
```
But now `co(...)` and `co.wrap(...)` return promises rather than functions. With this, you can do:
```
var readFile = thunkify(fs.readFile)
doStuff(co.callback(function* (data) {
  return yield readFile(data.file)
}))
```