### PR TITLE
Fix gitter link for npmjs.com

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # co
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/tj/co?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter][gitter-image]][gitter-url]
 [![NPM version][npm-image]][npm-url]
 [![Build status][travis-image]][travis-url]
 [![Test coverage][coveralls-image]][coveralls-url]
@@ -208,3 +208,5 @@ fn(true).then(function (val) {
 [coveralls-url]: https://coveralls.io/r/tj/co
 [downloads-image]: http://img.shields.io/npm/dm/co.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/co
+[gitter-image]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-url]: https://gitter.im/tj/co?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Currently gitter image is broken on https://www.npmjs.com/package/co

Problem was unencoded space %20. Also unified format to match other badges.

![image](https://cloud.githubusercontent.com/assets/43438/7197424/7fbfb9fa-e513-11e4-8c0a-963b9b529724.png)