### PR TITLE
publish co-browser.js to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "browserify": "browserify index.js -o ./co-browser.js -s co"
   },
   "files": [
+    "co-browser.js",
     "index.js"
   ],
   "license": "MIT",


### PR DESCRIPTION
When a repository lacks an `.npmignore` file, npm will fall back on `.gitignore`. Currently co's `.gitignore` specifies `co-browser.js` which is keeping it from being published to the npm even though it's generated in the prepublish npm step.

@jonathanong Looks good?