### PR TITLE
export condition for using with <script src>

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ var slice = Array.prototype.slice;
  * Expose `co`.
  */
 
-module.exports = co['default'] = co.co = co;
+if (typeof module !== 'undefined' && module.exports) {
+  exports = module.exports = co['default'] = co.co = co;
+}
 
 /**
  * Wrap the given generator `fn` into a


### PR DESCRIPTION
Hi.
When i connected `co` using `<script src="co.js">`, i got an error "module is not defined". When i added this condition all worked well. I think it's better to check environment before export.