### PR TITLE
Feature/byop

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "browserify": "^10.0.0",
     "istanbul-harmony": "0",
     "mocha": "^2.0.0",
-    "mz": "^1.0.2"
+    "mz": "^1.0.2",
+    "bluebird": "^2.10.1"
   },
   "scripts": {
     "test": "mocha --harmony",

--- a/test/byopromises.js
+++ b/test/byopromises.js
@@ -1,0 +1,105 @@
+
+var assert = require('assert');
+
+var co = require('..');
+var bluebird = require('bluebird');
+
+function getPromise(val, err) {
+  return new Promise(function (resolve, reject) {
+    if (err) reject(err);
+    else resolve(val);
+  });
+}
+
+describe('co(* -> yield <promise> with BYOP', function(){
+  before(function() {
+    co.setPromiseLibrary(bluebird);
+  });
+  after(function() {
+    co.setPromiseLibrary(Promise);
+  });
+  describe('with one promise yield', function(){
+    it('should work', function(){
+      return co(function *(){
+        var a = yield getPromise(1);
+        assert.equal(1, a);
+      });
+    })
+  })
+
+  describe('with several promise yields', function(){
+    it('should work', function(){
+      return co(function *(){
+        var a = yield getPromise(1);
+        var b = yield getPromise(2);
+        var c = yield getPromise(3);
+
+        assert.deepEqual([1, 2, 3], [a, b, c]);
+      });
+    })
+  })
+
+  describe('when a promise is rejected', function(){
+    it('should throw and resume', function(){
+      var error;
+
+      return co(function *(){
+        try {
+          yield getPromise(1, new Error('boom'));
+        } catch (err) {
+          error = err;
+        }
+
+        assert('boom' == error.message);
+        var ret = yield getPromise(1);
+        assert(1 == ret);
+      });
+    })
+  })
+
+  describe('when yielding a non-standard promise-like', function(){
+    it('should return the BYOP type promise', function() {
+      assert(co(function *(){
+        yield { then: function(){} };
+      }) instanceof bluebird);
+    });
+  })
+})
+
+describe('co(function) -> promise', function(){
+  it('return value', function(done){
+    co(function(){
+      return 1;
+    }).then(function(data){
+      assert.equal(data, 1);
+      done();
+    })
+  })
+
+  it('return resolve promise', function(){
+    return co(function(){
+      return Promise.resolve(1);
+    }).then(function(data){
+      assert.equal(data, 1);
+    })
+  })
+
+  it('return reject promise', function(){
+    return co(function(){
+      return Promise.reject(1);
+    }).catch(function(data){
+      assert.equal(data, 1);
+    })
+  })
+
+  it('should catch errors', function(){
+    return co(function(){
+      throw new Error('boom');
+    }).then(function () {
+      throw new Error('nope');
+    }).catch(function (err) {
+      assert.equal(err.message, 'boom');
+    });
+  })
+})
+


### PR DESCRIPTION
This allows a user to provide their own promise library; this is useful as there are libraries which offer benefits over the ES6 Promise object but are also API-compatible (or could be easily made to be so).  One particular benefit of using the same promise is that some libraries (notably q and bluebird) support long stack traces across multiple callbacks which is useful for debugging; however, when using a different promise in the middle (or particularly the end) of the chain breaks this functionality.

This is referred to in some libraries as Bring Your Own Promise (BYOP) and is very important to those of us who use third party promise libraries.  I have copied the promise unit tests to a byopromises unit test file which performs all of those tests with bluebird set as the Promise type and verifies that it works.