### PR TITLE
fix generator test

### DIFF
--- a/test/generators.js
+++ b/test/generators.js
@@ -14,27 +14,27 @@ function *work() {
 }
 
 describe('co(*)', function(){
-  describe('with a generator function', function(){
+  describe('with a generator', function(){
     it('should wrap with co()', function(){
       return co(function *(){
-        var a = yield work;
-        var b = yield work;
-        var c = yield work;
+        var a = yield work();
+        var b = yield work();
+        var c = yield work();
 
         assert('yay' == a);
         assert('yay' == b);
         assert('yay' == c);
 
-        var res = yield [work, work, work];
+        var res = yield [work(), work(), work()];
         assert.deepEqual(['yay', 'yay', 'yay'], res);
       });
     })
 
     it('should catch errors', function(){
       return co(function *(){
-        yield function *(){
+        yield (function *(){
           throw new Error('boom');
-        };
+        })();
       }).then(function () {
         throw new Error('wtf')
       }, function (err) {


### PR DESCRIPTION
now, https://github.com/tj/co/blob/e679907d5e06b48e5d7523a856b75ca21eec8349/test/generators.js is the same as https://github.com/tj/co/blob/e679907d5e06b48e5d7523a856b75ca21eec8349/test/generator-functions.js .

`work()` would produce a generator, while `work` is a generator function. so I think we should explicit call `work`, avoiding it enter this condition: https://github.com/tj/co/blob/e679907d5e06b48e5d7523a856b75ca21eec8349/index.js#L51

then the test make sense