### PR TITLE
Ponyfill Promise with pinkie-promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 node_js:
+- "0.10"
 - "0.12"
 - "iojs"
+- "4"
+- "stable"
 language: node_js
 script: "npm run-script test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,12 @@
-# co
+# co-with-promise
 
 [![Gitter][gitter-image]][gitter-url]
 [![NPM version][npm-image]][npm-url]
 [![Build status][travis-image]][travis-url]
 [![Test coverage][coveralls-image]][coveralls-url]
 [![Downloads][downloads-image]][downloads-url]
+
+This is a fork of [co](https://github.com/tj/co) with [Promise ponyfill](https://github.com/floatdrop/pinkie-promise) inside.
 
   Generator based control flow goodness for nodejs and the browser,
   using promises, letting you write non-blocking code in a nice-ish way.
@@ -200,13 +202,13 @@ fn(true).then(function (val) {
 
   MIT
 
-[npm-image]: https://img.shields.io/npm/v/co.svg?style=flat-square
-[npm-url]: https://npmjs.org/package/co
-[travis-image]: https://img.shields.io/travis/tj/co.svg?style=flat-square
-[travis-url]: https://travis-ci.org/tj/co
-[coveralls-image]: https://img.shields.io/coveralls/tj/co.svg?style=flat-square
-[coveralls-url]: https://coveralls.io/r/tj/co
-[downloads-image]: http://img.shields.io/npm/dm/co.svg?style=flat-square
-[downloads-url]: https://npmjs.org/package/co
+[npm-image]: https://img.shields.io/npm/v/co-with-promise.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/co-with-promise
+[travis-image]: https://img.shields.io/travis/tj/co-with-promise.svg?style=flat-square
+[travis-url]: https://travis-ci.org/tj/co-with-promise
+[coveralls-image]: https://img.shields.io/coveralls/tj/co-with-promise.svg?style=flat-square
+[coveralls-url]: https://coveralls.io/r/tj/co-with-promise
+[downloads-image]: http://img.shields.io/npm/dm/co-with-promise.svg?style=flat-square
+[downloads-url]: https://npmjs.org/package/co-with-promise
 [gitter-image]: https://badges.gitter.im/Join%20Chat.svg
 [gitter-url]: https://gitter.im/tj/co?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/Readme.md
+++ b/Readme.md
@@ -204,10 +204,10 @@ fn(true).then(function (val) {
 
 [npm-image]: https://img.shields.io/npm/v/co-with-promise.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/co-with-promise
-[travis-image]: https://img.shields.io/travis/tj/co-with-promise.svg?style=flat-square
-[travis-url]: https://travis-ci.org/tj/co-with-promise
-[coveralls-image]: https://img.shields.io/coveralls/tj/co-with-promise.svg?style=flat-square
-[coveralls-url]: https://coveralls.io/r/tj/co-with-promise
+[travis-image]: https://img.shields.io/travis/floatdrop/co-with-promise.svg?style=flat-square
+[travis-url]: https://travis-ci.org/floatdrop/co-with-promise
+[coveralls-image]: https://img.shields.io/coveralls/floatdrop/co-with-promise.svg?style=flat-square
+[coveralls-url]: https://coveralls.io/r/floatdrop/co-with-promise
 [downloads-image]: http://img.shields.io/npm/dm/co-with-promise.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/co-with-promise
 [gitter-image]: https://badges.gitter.im/Join%20Chat.svg

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var PinkiePromise = require('pinkie-promise');
 
 /**
  * slice() reference.
@@ -47,7 +48,7 @@ function co(gen) {
   // we wrap everything in a promise to avoid promise chaining,
   // which leads to memory leak errors.
   // see https://github.com/tj/co/issues/180
-  return new Promise(function(resolve, reject) {
+  return new PinkiePromise(function(resolve, reject) {
     if (typeof gen === 'function') gen = gen.apply(ctx, args);
     if (!gen || typeof gen.next !== 'function') return resolve(gen);
 
@@ -132,7 +133,7 @@ function toPromise(obj) {
 
 function thunkToPromise(fn) {
   var ctx = this;
-  return new Promise(function (resolve, reject) {
+  return new PinkiePromise(function (resolve, reject) {
     fn.call(ctx, function (err, res) {
       if (err) return reject(err);
       if (arguments.length > 2) res = slice.call(arguments, 1);
@@ -173,7 +174,7 @@ function objectToPromise(obj){
     if (promise && isPromise(promise)) defer(promise, key);
     else results[key] = obj[key];
   }
-  return Promise.all(promises).then(function () {
+  return PinkiePromise.all(promises).then(function () {
     return results;
   });
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   "engines": {
     "iojs": ">= 1.0.0",
     "node": ">= 0.12.0"
+  },
+  "dependencies": {
+    "pinkie-promise": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "co",
+  "name": "co-with-promise",
   "version": "4.6.0",
   "description": "generator async control flow goodness",
   "keywords": [
@@ -30,7 +30,7 @@
   "repository": "tj/co",
   "engines": {
     "iojs": ">= 1.0.0",
-    "node": ">= 0.12.0"
+    "node": ">= 0.10.0"
   },
   "dependencies": {
     "pinkie-promise": "^1.0.0"


### PR DESCRIPTION
Alternative way to support Node.js 0.10 (see #244).

We are using `co` in [ava](https://github.com/sindresorhus/ava) test framework and polyfilling global Promise object is not working for us, because it will affect code under testing. If code under testing relies on Promise object and we polyfill it globally it will pass tests on Node.js 0.10, but will fail in production.

This approach supports polyfilling global Promise with `global.Promise = require('bluebird');` and returns native promises (if available). If neither works it will return small [pinkie](https://github.com/floatdrop/pinkie) polyfill.