### PR TITLE
Returning promise to prevent bluebird warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function co(gen) {
       } catch (e) {
         return reject(e);
       }
-      next(ret);
+      return next(ret);
     }
 
     /**
@@ -82,7 +82,7 @@ function co(gen) {
       } catch (e) {
         return reject(e);
       }
-      next(ret);
+      return next(ret);
     }
 
     /**


### PR DESCRIPTION
If you are running `bluebird` and using `koa-static`, you get a spew of warnings from `bluebird` about a promise is created but not returned. I tracked it down to this and confirmed that it fixed all the warnings.