### PR TITLE
Avoid warning when using bluebird as Promise implementation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function co(gen) {
         return reject(e);
       }
       next(ret);
+      return null;
     }
 
     /**


### PR DESCRIPTION
Hi,
I am using co with [bluebird](https://github.com/petkaantonov/bluebird) promise implementation,
but Bluebird 3.0 now emits a warning when a promise callback does not return explicitly.

https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it

The feature can be useful, but clearly here there is no need for a warning,
so this should help combining the two.