### PR TITLE
fix isObject function for null value

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,5 +233,5 @@ function isGeneratorFunction(obj) {
  */
 
 function isObject(val) {
-  return Object == val.constructor;
+  return val.constructor && Object == val.constructor;
 }


### PR DESCRIPTION
isObject function threw *Uncaught TypeError: Cannot read property 'constructor' of null(…)* for null arg value.