### PR TITLE
Redefine length property of wrapped function

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ module.exports = co['default'] = co.co = co;
  */
 
 co.wrap = function (fn) {
-  createPromise.__generatorFunction__ = fn;
-  return Object.defineProperty(createPromise, 'length', { value: fn.length });
+  var wrapped = Function.apply(null, Array.apply(null, { length: fn.length }).concat('this()')).bind(createPromise);
+  wrapped.__generatorFunction__ = fn;
+  return wrapped;
   function createPromise() {
     return co.call(this, fn.apply(this, arguments));
   }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = co['default'] = co.co = co;
 
 co.wrap = function (fn) {
   createPromise.__generatorFunction__ = fn;
-  return createPromise;
+  return Object.defineProperty(createPromise, 'length', { value: fn.length });
   function createPromise() {
     return co.call(this, fn.apply(this, arguments));
   }

--- a/test/wrap.js
+++ b/test/wrap.js
@@ -3,6 +3,8 @@ var assert = require('assert');
 
 var co = require('..');
 
+function* noop(a, b, c) {}
+
 describe('co.wrap(fn*)', function () {
   it('should pass context', function () {
     var ctx = {
@@ -20,8 +22,12 @@ describe('co.wrap(fn*)', function () {
     })(1, 2, 3);
   })
 
+  it('should match arguments length', function () {
+    assert(co.wrap(noop).length === noop.length);
+  })
+
   it('should expose the underlying generator function', function () {
-    var wrapped = co.wrap(function* (a, b, c) {});
+    var wrapped = co.wrap(noop);
     var source = Object.toString.call(wrapped.__generatorFunction__);
     assert(source.indexOf('function*') === 0);
   })


### PR DESCRIPTION
Makes wrapped functions compatible when passed as argument to functions that checks argument length of the passed function.