### PR TITLE
Add co.wrapAll

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -196,6 +196,38 @@ fn(true).then(function (val) {
 });
 ```
 
+### co.wrapAll({ fn* })
+
+Apply the above wrapping to all generator functions found in the own properties
+of an object.
+
+```js
+var obj = {
+  fn: function* (val) {
+    return yield Promise.resolve(val);
+  }
+};
+
+co.wrapAll(obj);
+
+obj.fn(true).then(function (val) {
+
+});
+```
+
+This is especially useful for a class `prototype`, in order to define
+asynchronous methods.
+
+```js
+class Foo {
+  *bar(val) {
+    return yield Promise.resolve(val);
+  }
+}
+
+co.wrapAll(Foo.prototype);
+```
+
 ## License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -32,6 +32,33 @@ co.wrap = function (fn) {
 };
 
 /**
+ * Wrap all the generator functions found
+ * in the own properties of the given `obj`.
+ * This is especially useful for a class
+ * `prototype`, in order to define async
+ * methods.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api public
+ */
+
+co.wrapAll = function (obj) {
+  var keys = Object.getOwnPropertyNames(obj);
+
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var value = obj[key];
+
+    if (value && isGeneratorFunction(value)) {
+      obj[key] = co.wrap(value);
+    }
+  }
+
+  return obj;
+}
+
+/**
  * Execute the generator function or a generator
  * and return a promise.
  *

--- a/test/wrap-all.js
+++ b/test/wrap-all.js
@@ -1,0 +1,58 @@
+
+var assert = require('assert');
+
+var co = require('..');
+
+describe('co.wrapAll({ fn* })', function () {
+  it('should wrap all generator functions', function () {
+    var obj = {
+      foo: function* (val) {
+        return yield Promise.resolve(val);
+      },
+      bar: function* (val) {
+        return val;
+      },
+      baz: function (val) {
+        return val;
+      }
+    };
+
+    co.wrapAll(obj);
+
+    return co(function* () {
+      yield obj.foo(1).then(function (val) {
+        assert.equal(1, val);
+      });
+
+      yield obj.bar(2).then(function (val) {
+        assert.equal(2, val);
+      });
+
+      assert.equal(3, obj.baz(3));
+    });
+  })
+
+  it('should wrap non-enumerable properties', function () {
+    var obj = {
+      foo: function* (val) {
+        return yield Promise.resolve(val);
+      }
+    };
+
+    Object.defineProperty(obj, 'foo', {enumerable: false});
+
+    co.wrapAll(obj);
+
+    return obj.foo(42).then(function (val) {
+      assert.equal(42, val);
+    });
+  })
+
+  it('should return the wrapped object', function () {
+    var obj = {
+      foo: function* () {}
+    };
+
+    assert.equal(obj, co.wrapAll(obj));
+  })
+})


### PR DESCRIPTION
This tiny helper allows to easily call `co.wrap` for multiple generator functions.
For example:

```js
// Before
module.exports = {
    foo: co.wrap(foo),
    bar: co.wrap(bar)
};

// After
module.exports = co.wrapAll({foo, bar});
```

Also, it is very convenient for defining asynchronous methods:

```js
// Common
class Foo {
    * bar(val) { /* ... */ }
    * baz(val) { /* ... */ }
}

// Before
Foo.prototype.bar = co.wrap(Foo.prototype.bar);
Foo.prototype.baz = co.wrap(Foo.prototype.baz);

// After
co.wrapAll(Foo.prototype);
```