### PR TITLE
async/await is not part of ES7

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@
 ## Co v4
 
   `co@4.0.0` has been released, which now relies on promises.
-  It is a stepping stone towards [ES7 async/await](https://github.com/lukehoban/ecmascript-asyncawait).
+  It is a stepping stone towards the [async/await proposal](https://github.com/lukehoban/ecmascript-asyncawait).
   The primary API change is how `co()` is invoked.
   Before, `co` returned a "thunk", which you then called with a callback and optional arguments.
   Now, `co()` returns a promise.


### PR DESCRIPTION
I assume ES7 is a synonym for ES2016 here. ES2016 was just released and async/await is not a part of it. I believe keeping this expression will confuse people who don't really follow the standard process.