### PR TITLE
choose Promise which you like

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -196,6 +196,17 @@ fn(true).then(function (val) {
 });
 ```
 
+### co.setPromise(Promise)
+
+You can custom `Promise` that you like . Such as `bluebird`, `q`, `when` and so on.
+
+```js
+var Promise = require('bluebird');
+co.setPromise(Promise);
+
+co(11).tap(console.log);
+```
+
 ## License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -6,10 +6,24 @@
 var slice = Array.prototype.slice;
 
 /**
+ * default Promise
+ */
+
+var Promise = global.Promise;
+
+/**
  * Expose `co`.
  */
 
 module.exports = co['default'] = co.co = co;
+
+/**
+ * custom your Promise that you like
+ */
+
+co.setPromise = function (promise) {
+  Promise = promise;
+}
 
 /**
  * Wrap the given generator `fn` into a


### PR DESCRIPTION
if we don't like to use native Promise, we can choose other Promises, such as bluebird.
```js
co.set(require('bluebird'));
co(1).tap(console.log);
```
by using it ,we can use the `tap` function of Promise