### PR TITLE
Add nodejs stable and LTS versions to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 node_js:
+- "stable"
+- "4"
 - "0.12"
 - "iojs"
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 node_js:
 - "stable"
 - "4"
-- "0.12"
 - "iojs"
+- "0.12"
 language: node_js
 script: "npm run-script test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
Tests were enabled only for versions v0.12 and io.js v3.3.1.
I enabled the tests to run on the LTS and stable versions.