### PR TITLE
remove strange return instead return the next function return value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,7 @@ function co(gen) {
       } catch (e) {
         return reject(e);
       }
-      next(ret);
-      return null;
+      return next(ret);
     }
 
     /**


### PR DESCRIPTION
since the `return null` is to avoid bluebird promise warnings, then the more properly way to fix this is to `return next(ret) `.